### PR TITLE
Implementation of TokenHolder.getSessionKeyData needed for JLP

### DIFF
--- a/lib/ContractInteract/GnosisSafe.js
+++ b/lib/ContractInteract/GnosisSafe.js
@@ -272,7 +272,7 @@ class GnosisSafe {
    * @return {Promise<Object>} Promise that resolves to array of owners.
    */
   getOwners() {
-    return this.contract.methods.getOwners().call();
+    return Promise.resolve(this.contract.methods.getOwners().call());
   }
 
   /**
@@ -281,7 +281,7 @@ class GnosisSafe {
    * @return {Promise<Object>} Promise that resolves current GnosisSafe nonce.
    */
   getNonce() {
-    return this.contract.methods.nonce().call();
+    return Promise.resolve(this.contract.methods.nonce().call());
   }
 
   /**
@@ -373,7 +373,7 @@ class GnosisSafe {
    * @returns {string} domain separator value.
    */
   async getDomainSeparator() {
-    return this.contract.methods.domainSeparator().call();
+    return Promise.resolve(this.contract.methods.domainSeparator().call());
   }
 
   /**
@@ -382,7 +382,7 @@ class GnosisSafe {
    * @returns {Object} Map of all modules.
    */
   async getModules() {
-    return this.contract.methods.getModules().call();
+    return Promise.resolve(this.contract.methods.getModules().call());
   }
 }
 

--- a/lib/ContractInteract/PricerRule.js
+++ b/lib/ContractInteract/PricerRule.js
@@ -143,7 +143,7 @@ class PricerRule {
     const abiBinProvider = new AbiBinProvider();
     const bin = abiBinProvider.getBIN(ContractName);
 
-    const bytesBaseCurrencyCode = this.auxiliaryWeb3.utils.stringToHex(baseCurrencyCode);
+    const bytesBaseCurrencyCode = auxiliaryWeb3.utils.stringToHex(baseCurrencyCode);
     const args = [
       organization,
       eip20Token,

--- a/lib/ContractInteract/TokenHolder.js
+++ b/lib/ContractInteract/TokenHolder.js
@@ -188,6 +188,15 @@ class TokenHolder {
     }
     return Promise.resolve(this.contract.methods.executeRule(to, data, nonce, r, s, v));
   }
+
+  /**
+   * It returns the session key data object.
+   *
+   * @return {Promise<Object>} Promise that resolves current GnosisSafe nonce.
+   */
+  getSessionKeyData(sessionKey) {
+    return Promise.resolve(this.contract.methods.sessionKeys().call(sessionKey));
+  }
 }
 
 module.exports = TokenHolder;

--- a/lib/ContractInteract/TokenHolder.js
+++ b/lib/ContractInteract/TokenHolder.js
@@ -110,6 +110,10 @@ class TokenHolder {
    * @returns {string} Executable data to revoke a session.
    */
   getRevokeSessionExecutableData(sessionKey) {
+    if (!Web3.utils.isAddress(sessionKey)) {
+      const err = new TypeError(`Invalid sessionKey address: ${sessionKey}.`);
+      return Promise.reject(err);
+    }
     return this.contract.methods.revokeSession(sessionKey).encodeABI();
   }
 
@@ -192,10 +196,16 @@ class TokenHolder {
   /**
    * It returns the session key data object.
    *
+   * @param {string} sessionKey Authorized session key address.
+   *
    * @return {Promise<Object>} Promise that resolves current GnosisSafe nonce.
    */
   getSessionKeyData(sessionKey) {
-    return Promise.resolve(this.contract.methods.sessionKeys().call(sessionKey));
+    if (!Web3.utils.isAddress(sessionKey)) {
+      const err = new TypeError(`Invalid sessionKey address: ${sessionKey}.`);
+      return Promise.reject(err);
+    }
+    return Promise.resolve(this.contract.methods.sessionKeys(sessionKey).call());
   }
 }
 

--- a/lib/ContractInteract/TokenHolder.js
+++ b/lib/ContractInteract/TokenHolder.js
@@ -198,7 +198,7 @@ class TokenHolder {
    *
    * @param {string} sessionKey Authorized session key address.
    *
-   * @return {Promise<Object>} Promise that resolves current GnosisSafe nonce.
+   * @return {Promise<Object>} Promise that resolves session data for valid session key.
    */
   getSessionKeyData(sessionKey) {
     if (!Web3.utils.isAddress(sessionKey)) {

--- a/test/unit/TokenHolder/getRevokeSessionExecutableData.js
+++ b/test/unit/TokenHolder/getRevokeSessionExecutableData.js
@@ -34,7 +34,7 @@ describe('TokenHolder.getAuthorizeSessionWithExecutableData()', () => {
     Spy.assert(revokeSessionSpy, 1, [[sessionKey]]);
   });
 
-  it('should throw an error when to address is undefined', async () => {
+  it('should throw an error when sessoinKey address is undefined', async () => {
     const sessionKey = undefined;
     await AssertAsync.reject(tokenHolder.getSessionKeyData(sessionKey), `Invalid sessionKey address: undefined.`);
   });

--- a/test/unit/TokenHolder/getRevokeSessionExecutableData.js
+++ b/test/unit/TokenHolder/getRevokeSessionExecutableData.js
@@ -5,6 +5,7 @@ const sinon = require('sinon');
 const { assert } = require('chai');
 
 const Spy = require('../../../utils/Spy');
+const AssertAsync = require('../../../utils/AssertAsync');
 const TokenHolder = require('../../../lib/ContractInteract/TokenHolder');
 
 describe('TokenHolder.getAuthorizeSessionWithExecutableData()', () => {
@@ -31,5 +32,10 @@ describe('TokenHolder.getAuthorizeSessionWithExecutableData()', () => {
 
     assert.strictEqual(response, mockRevokeSession);
     Spy.assert(revokeSessionSpy, 1, [[sessionKey]]);
+  });
+
+  it('should throw an error when to address is undefined', async () => {
+    const sessionKey = undefined;
+    await AssertAsync.reject(tokenHolder.getSessionKeyData(sessionKey), `Invalid sessionKey address: undefined.`);
   });
 });

--- a/test/unit/TokenHolder/getSessionKeyData.js
+++ b/test/unit/TokenHolder/getSessionKeyData.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const Web3 = require('web3');
+const sinon = require('sinon');
+const { assert } = require('chai');
+
+const Spy = require('../../../utils/Spy');
+const TokenHolder = require('../../../lib/ContractInteract/TokenHolder');
+
+describe('TokenHolder.getLogoutExecutableData()', () => {
+  let tokenHolder;
+
+  beforeEach(() => {
+    const web3 = new Web3();
+    const address = '0x0000000000000000000000000000000000000002';
+    tokenHolder = new TokenHolder(web3, address);
+  });
+
+  it('should construct with correct parameters', async () => {
+    const mockSessionKeyData = 'mockSessionKeyData';
+    const logoutSpy = sinon.replace(
+      tokenHolder.contract.methods,
+      'sessionKeys',
+      sinon.fake.returns({
+        call: () => Promise.resolve(mockSessionKeyData)
+      })
+    );
+    const response = await tokenHolder.getSessionKeyData();
+
+    assert.strictEqual(response, mockSessionKeyData);
+    Spy.assert(logoutSpy, 1, [[]]);
+  });
+});

--- a/test/unit/TokenHolder/getSessionKeyData.js
+++ b/test/unit/TokenHolder/getSessionKeyData.js
@@ -34,7 +34,7 @@ describe('TokenHolder.getSessionKeyData()', () => {
     Spy.assert(sessionKeyDataSpy, 1, [[sessionKey]]);
   });
 
-  it('should throw an error when to address is undefined', async () => {
+  it('should throw an error when sessoinKey address is undefined', async () => {
     const sessionKey = undefined;
     await AssertAsync.reject(tokenHolder.getSessionKeyData(sessionKey), `Invalid sessionKey address: undefined.`);
   });

--- a/test/unit/TokenHolder/getSessionKeyData.js
+++ b/test/unit/TokenHolder/getSessionKeyData.js
@@ -5,9 +5,10 @@ const sinon = require('sinon');
 const { assert } = require('chai');
 
 const Spy = require('../../../utils/Spy');
+const AssertAsync = require('../../../utils/AssertAsync');
 const TokenHolder = require('../../../lib/ContractInteract/TokenHolder');
 
-describe('TokenHolder.getLogoutExecutableData()', () => {
+describe('TokenHolder.getSessionKeyData()', () => {
   let tokenHolder;
 
   beforeEach(() => {
@@ -17,17 +18,24 @@ describe('TokenHolder.getLogoutExecutableData()', () => {
   });
 
   it('should construct with correct parameters', async () => {
+    const sessionKey = '0x0000000000000000000000000000000000000003';
+
     const mockSessionKeyData = 'mockSessionKeyData';
-    const logoutSpy = sinon.replace(
+    const sessionKeyDataSpy = sinon.replace(
       tokenHolder.contract.methods,
       'sessionKeys',
       sinon.fake.returns({
         call: () => Promise.resolve(mockSessionKeyData)
       })
     );
-    const response = await tokenHolder.getSessionKeyData();
+    const response = await tokenHolder.getSessionKeyData(sessionKey);
 
     assert.strictEqual(response, mockSessionKeyData);
-    Spy.assert(logoutSpy, 1, [[]]);
+    Spy.assert(sessionKeyDataSpy, 1, [[sessionKey]]);
+  });
+
+  it('should throw an error when to address is undefined', async () => {
+    const sessionKey = undefined;
+    await AssertAsync.reject(tokenHolder.getSessionKeyData(sessionKey), `Invalid sessionKey address: undefined.`);
   });
 });


### PR DESCRIPTION
PR covers below:
- Implementation of TokenHolder.getSessionKeyData method.
- Unit test cases.
- Validation for sessionKey in getRevokeSessionExecutableData.