### PR TITLE
TokenHolder ContractInteract fix order r,s,v

### DIFF
--- a/lib/ContractInteract/TokenHolder.js
+++ b/lib/ContractInteract/TokenHolder.js
@@ -133,7 +133,7 @@ class TokenHolder {
    */
   getTokenHolderExecuteRuleCallPrefix() {
     const executeRuleHash = this.auxiliaryWeb3.utils.soliditySha3(
-      'executeRule(address,bytes,uint256,uint8,bytes32,bytes32)'
+      'executeRule(address,bytes,uint256,bytes32,bytes32,uint8)'
     );
     const executeRuleCallPrefix = executeRuleHash.substring(0, 10);
     return executeRuleCallPrefix;

--- a/lib/helper/TokenHolder.js
+++ b/lib/helper/TokenHolder.js
@@ -82,7 +82,7 @@ class TokenHolder {
     const oThis = this;
 
     const executeRuleHash = oThis.auxiliaryWeb3.utils.soliditySha3(
-      'executeRule(address,bytes,uint256,uint8,bytes32,bytes32)'
+      'executeRule(address,bytes,uint256,bytes32,bytes32,uint8)'
     );
     const executeRuleCallPrefix = executeRuleHash.substring(0, 10);
 


### PR DESCRIPTION
fix order of r,s,v; should be followed up and use ABI properly, rather than using a hard-coded string